### PR TITLE
Standardize tox github actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,8 +1,16 @@
-name: CI/CD Builds
+name: tox
 
-"on":
-  push:
+on:
+  create:  # is used for publishing to PyPI and TestPyPI
+    tags:  # any tag regardless of its name, no branches
+  push:  # only publishes pushes to the main branch to TestPyPI
+    branches:  # any integration branch but not tag
+      - "master"
+    tags-ignore:
+      - "**"
   pull_request:
+  schedule:
+    - cron: 1 0 * * *  # Run daily at 0:01 UTC
 
 jobs:
   lint:


### PR DESCRIPTION
Adopts model from molecule project where we have on "tox" workflow which also runs on schedule.

This will also enable us to have a single dashboard with status of all scheduled jobs.

Note: workflow name is important to be simple and consistent as it is used for building urls. See https://github.com/ansible-community/molecule/wiki