### PR TITLE
Suppress extraneous directory creation

### DIFF
--- a/src/tox_ansible/tox_helper.py
+++ b/src/tox_ansible/tox_helper.py
@@ -53,6 +53,11 @@ class Tox(object):
         """Returns any configured posargs from the tox world"""
         return self.config.option.args
 
+    @property
+    def toxinidir(self):
+        """Returns the configured toxinidir for working with base directory paths"""
+        return self.config.homedir
+
     def get_opts(self):
         """Return the options as a dictionary-style object.
 

--- a/src/tox_ansible/tox_lint_case.py
+++ b/src/tox_ansible/tox_lint_case.py
@@ -1,6 +1,7 @@
 from copy import copy
 
 from .tox_base_case import ToxBaseCase
+from .tox_helper import Tox
 
 BASH = "cd {} && molecule {} lint -s {}"
 
@@ -9,6 +10,7 @@ class ToxLintCase(ToxBaseCase):
     def __init__(self, cases, name_parts=[]):
         self._cases = copy(cases)
         self._name_parts = name_parts
+        self._config = Tox()
         super(ToxLintCase, self).__init__()
 
     def get_commands(self, options):
@@ -28,7 +30,7 @@ class ToxLintCase(ToxBaseCase):
         return cmds
 
     def get_working_dir(self):
-        return "{toxinidir}"
+        return self._config.toxinidir
 
     def get_dependencies(self):
         deps = set(["molecule", "flake8", "ansible-lint", "yamllint"])

--- a/tests/test_tox_lint_case.py
+++ b/tests/test_tox_lint_case.py
@@ -7,11 +7,16 @@ except ImportError:
     from mock import Mock
 
 
-def test_names_are_correct():
+def test_names_are_correct(mocker):
     tc = ToxLintCase([])
     deps = set(["molecule", "ansible-lint", "flake8", "yamllint"])
+    mocker.patch(
+        "tox_ansible.tox_lint_case.Tox.toxinidir",
+        new_callable=mocker.PropertyMock,
+        return_value="/home",
+    )
     assert tc.get_name() == "lint_all"
-    assert tc.get_working_dir() == "{toxinidir}"
+    assert tc.get_working_dir() == "/home"
     assert tc.get_dependencies() == deps
 
 


### PR DESCRIPTION
Prevent tox-ansible from accidentally creating a directory literally
named '{toxinidir}'.

Fix: #19