### PR TITLE
Streamline scenario detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,12 @@ molecule_opts =
     --debug
 ```
 
-Once you've run the tests in your local directory a few times you'll find that the plugin
-might begin picking up code that lives inside of the Tox working directory, typically called
-`.tox`. To prevent the plugin from finding scenarios inside that directory, or anywhere else,
-you can add elements to the ignore list:
+Sometimes there are paths you will want to ignore running tests in. Particularly if you
+install other roles or collections underneath of your source tree. You can ignore these paths
+with the following tox.ini bit:
 ```ini
 [ansible]
 ignore_path =
-    .tox
     dist
     generated_paths_to_ignore
 ```
@@ -208,7 +206,7 @@ python
 Under the hood
 --------------
 
-The plugin will walk the current directory and look for any files matching the glob pattern
+The plugin will glob the current directory and look for any files matching the glob pattern
 `molecule/*/molecule.yml` and make the assumption that these represent Molecule scenarios.
 
 It then generates new environments for any discovered scenarios that do not already exist

--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -1,4 +1,5 @@
-from os import path, walk
+import glob
+from os import path
 
 from ..tox_lint_case import ToxLintCase
 from ..tox_test_case import ToxTestCase
@@ -39,20 +40,20 @@ class Ansible(object):
         if self._scenarios is not None:
             return self._scenarios
         self._scenarios = []
-        for folder, dirs, files in walk(self.directory):
-            tree = folder.split(path.sep)
+        files = glob.glob(
+            f"{self.directory}/**/molecule/*/molecule.yml", recursive=True
+        )
+        for file in files:
+            # Check scenario path
+            base_dir = path.dirname(file)
             # Find if it's anywhere in the ignore list
+            tree = base_dir.split("/")
             ignored = False
             for branch in tree:
                 if branch in self.options.ignore_paths:
                     ignored = True
-            if (
-                not ignored
-                and len(tree) >= 2
-                and tree[-2] == "molecule"
-                and "molecule.yml" in files
-            ):
-                self._scenarios.append(Scenario(path.relpath(folder, self.directory)))
+            if not ignored:
+                self._scenarios.append(Scenario(path.relpath(base_dir, self.directory)))
         return self._scenarios
 
     @property


### PR DESCRIPTION
Skip os.walk and use glob.glob to find scenario files. It means that
dot-directories are ignored, but the resulting calls are MUCH faster and
we probably want to ignore dotfiles anyway

Fix: #25 