### PR TITLE
Adopt setuptools packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ htmlcov
 build
 dist
 .idea
+.eggs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[build-system]
+requires = [
+  "setuptools >= 42.0.0",  # required by pyproject+setuptools_scm integration
+  "setuptools_scm[toml] >= 3.5.0",  # required for "no-local-version" scheme
+  "setuptools_scm_git_archive >= 1.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 skip-string-normalization = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,55 @@
+[metadata]
+name = tox-ansible
+url = https://github.com/ansible-community/tox-ansible
+project_urls =
+    Bug Tracker = https://github.com/ansible-community/tox-ansible/issues
+    Release Management = https://github.com/ansible-community/tox-ansible/releases
+    CI = https://github.com/ansible-community/tox-ansible/actions
+    Source Code = https://github.com/ansible-community/tox-ansible
+description = Auto-generate environments for molecule role testing
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Greg Hellings
+author_email = greg.hellings@gmail.com
+maintainer = Greg Hellings
+maintainer_email = greg.hellings@gmail.com
+license = GPLv3
+; license_file = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Framework :: tox
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Testing
+keywords =
+    ansible
+    tox
+    tox-plugin
+
+[options]
+use_scm_version = True
+python_requires = >=3.6
+package_dir =
+  = src
+packages = find:
+include_package_data = True
+zip_safe = False
+
+# These are required during `setup.py` run:
+setup_requires =
+  setuptools_scm>=1.15.0
+  setuptools_scm_git_archive>=1.0
+
+# These are required in actual runtime:
+install_requires =
+  tox >= 2.7
+  pyyaml
+
+[options.entry_points]
+tox =
+  ansible-collection = tox_ansible.hooks
+
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,7 @@
-import io
+import setuptools
 
-from setuptools import find_packages, setup
-
-setup(
-    name="tox-ansible",
-    description="Auto-generate environments for molecule role testing",
-    long_description_content_type="text/markdown",
-    long_description=io.open("README.md", encoding="utf-8").read(),
-    author="Greg Hellings",
-    author_email="greg.hellings@gmail.com",
-    url="https://github.com/ansible-community/tox-ansible",
-    license="GPLv3",
-    version="0.11.0",
-    package_dir={"": "src"},
-    packages=find_packages("src"),
-    entry_points={"tox": ["ansible-collection = tox_ansible.hooks"]},
-    install_requires=["tox>=2.7", "pyyaml"],
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Framework :: tox",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Topic :: Software Development :: Testing",
-    ],
-)
+if __name__ == "__main__":
+    setuptools.setup(
+        use_scm_version={"local_scheme": "no-local-version"},
+        setup_requires=["setuptools_scm[toml]>=3.5.0"],
+    )


### PR DESCRIPTION
Moves package metadata to setup.cfg as setup.py was deprecated long time ago.

This enables git tag based versioning, making possible to make a new (pre)-release but just a tag creation, prefereably using https://github.com/ansible-community/tox-ansible/releases page.