### PR TITLE
Add support for more driver types

### DIFF
--- a/src/tox_ansible/tox_test_case.py
+++ b/src/tox_ansible/tox_test_case.py
@@ -4,7 +4,7 @@ from .tox_base_case import ToxBaseCase
 from .tox_helper import Tox
 
 DRIVER_DEPENDENCIES = {
-    # Because of the close relatoinship of these two, it's not uncommon to run one
+    # Because of the close relationship of these two, it's not uncommon to run one
     # scenario using the other driver if your system does not support one or the
     # other. So we'll choose to install only one of them
     "docker": ["molecule-docker", "molecule-podman"],

--- a/src/tox_ansible/tox_test_case.py
+++ b/src/tox_ansible/tox_test_case.py
@@ -4,10 +4,14 @@ from .tox_base_case import ToxBaseCase
 from .tox_helper import Tox
 
 DRIVER_DEPENDENCIES = {
-    "docker": ["docker"],
-    "openstack": ["openstacksdk", "molecule-openstack", "os-client-config"],
+    # Because of the close relatoinship of these two, it's not uncommon to run one
+    # scenario using the other driver if your system does not support one or the
+    # other. So we'll choose to install only one of them
+    "docker": ["molecule-docker", "molecule-podman"],
+    "podman": ["molecule-podman", "molecule-docker"],
+    "openstack": ["molecule-openstack", "openstacksdk", "os-client-config"],
     "ec2": ["molecule-ec2", "boto", "boto3"],
-    "podman": [],
+    "vagrant": ["molecule-vagrant"],
 }
 
 

--- a/tests/test_tox_test_case.py
+++ b/tests/test_tox_test_case.py
@@ -62,7 +62,7 @@ class TestToxTestCase(TestCase):
     def test_case_includes_docker_deps(self, driver_mock, config_mock):
         s = Scenario("moelcule/my_test")
         t = ToxTestCase(s)
-        self.assertIn("docker", t.get_dependencies())
+        self.assertIn("molecule-docker", t.get_dependencies())
 
     @mock.patch.object(
         Scenario, "driver", new_callable=mock.PropertyMock, return_value="openstack"

--- a/tests/test_tox_test_case.py
+++ b/tests/test_tox_test_case.py
@@ -60,7 +60,7 @@ class TestToxTestCase(TestCase):
         Scenario, "driver", new_callable=mock.PropertyMock, return_value="docker"
     )
     def test_case_includes_docker_deps(self, driver_mock, config_mock):
-        s = Scenario("moelcule/my_test")
+        s = Scenario("molecule/my_test")
         t = ToxTestCase(s)
         self.assertIn("molecule-docker", t.get_dependencies())
 


### PR DESCRIPTION
Add support for Vagrant driver
Add the molecule-{podman,docker} plugins to the dependencies
Add both docker/podman when either is selected so that someone on a
system not supporting one can run the tests for the other without
needing to mess with the dependencies support