### PR TITLE
Drop support for old tox versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-  tox >= 2.7
+  tox >= 3.18  # allowlist_externals
   pyyaml
 
 [options.entry_points]

--- a/src/tox_ansible/tox_helper.py
+++ b/src/tox_ansible/tox_helper.py
@@ -113,5 +113,5 @@ class Tox(object):
             config.changedir = py.path.local(tox_case.get_working_dir())
         if not config.basepython and tox_case.python is not None:
             config.basepython = tox_case.get_basepython()
-        if not config.whitelist_externals:
-            config.whitelist_externals = ["bash"]
+        if not config.allowlist_externals:
+            config.allowlist_externals = ["bash"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipdist = true
 ignore_path = tests
-envlist = py3{6,7,8,9}, py39-tox{2,3}0, lint, coverage
+envlist = py3{6,7,8,9}, lint, coverage
 
 [testenv]
 usedevelop = true
@@ -11,8 +11,6 @@ deps =
     pytest
     pytest-cov
     pytest-mock
-    tox30: tox==3.0
-    tox20: tox==2.7
 setenv =
     COVERAGE_FILE={env:COVERAGE_FILE:.coverage.{basepython}}
 commands =
@@ -20,7 +18,7 @@ commands =
 
 [testenv:coverage]
 parallel_show_output = true
-depends = py3{6,7,8,9}, py39-tox{2,3}0
+depends = py3{6,7,8,9}
 setenv =
 commands =
     coverage combine


### PR DESCRIPTION
In order to simplify maintenance of the project, we will support
only recent versions of tox and expose the minimal version in our
package metadata.

Since tox added support for bootstrapping itself requiring a minimal
version is no longer a problem.

This also fixes bug related to rename of whitelist, which prevented
used of tox-ansible by users using the new name.