### PR TITLE
Add packaging tox env

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,12 +3,14 @@ name: tox
 on:
   create:  # is used for publishing to PyPI and TestPyPI
     tags:  # any tag regardless of its name, no branches
+      - "**"
   push:  # only publishes pushes to the main branch to TestPyPI
     branches:  # any integration branch but not tag
       - "master"
-    tags-ignore:
-      - "**"
   pull_request:
+  release:
+    types:
+      - published  # It seems that you can publish directly without creating
   schedule:
     - cron: 1 0 * * *  # Run daily at 0:01 UTC
 
@@ -24,7 +26,17 @@ jobs:
         run: |
           python -m pip install -U tox
           tox -e lint
-
+  packaging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@master
+        with:
+          python-version: "3.x"
+      - name: run packaging
+        run: |
+          python -m pip install -U tox
+          tox -e packaging
   test:
     needs: lint
     runs-on: ubuntu-latest
@@ -72,26 +84,50 @@ jobs:
     needs: coverage
     if: startsWith(github.ref, 'refs/tags/')  # Only release during tags
     runs-on: ubuntu-latest
+
+    env:
+      PY_COLORS: 1
+      TOXENV: packaging
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@master
+      - name: Switch to using Python 3.6 by default
+        uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
-      - name: build
-        run: |
-          python -m pip install -U pip setuptools
-          pip install -U wheel
-          python setup.py build sdist bdist_wheel
-      - name: get tag name
-        id: get_tag
-        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-      - name: GitHub Release
-        uses: ncipollo/release-action@v1
+          python-version: 3.6
+      - name: Install tox
+        run: python -m pip install --user tox
+      - name: Check out src from Git
+        uses: actions/checkout@v2
         with:
-          artifacts: dist/*.whl, dist/*.tar.gz
-          allowUpdates: true
-          name: Release ${{ steps.get_tag.outputs.TAG }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Get shallow Git history (default) for release events
+          # but have a complete clone for any other workflows.
+          # Both options fetch tags but since we're going to remove
+          # one from HEAD in non-create-tag workflows, we need full
+          # history for them.
+          fetch-depth: >-
+            ${{
+              (
+                (
+                  github.event_name == 'create' &&
+                  github.event.ref_type == 'tag'
+                ) ||
+                github.event_name == 'release'
+              ) &&
+              1 || 0
+            }}
+      - name: Drop Git tags from HEAD for non-tag-create and non-release events
+        if: >-
+          (
+            github.event_name != 'create' ||
+            github.event.ref_type != 'tag'
+          ) &&
+          github.event_name != 'release'
+        run: >-
+          git tag --points-at HEAD
+          |
+          xargs git tag --delete
+      - name: Build dists
+        run: python -m tox
       - name: Publish to test.pypi.org
         if: >-
           (
@@ -110,8 +146,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
       - name: Publish to pypi.org
         if: >-  # "create" workflows run separately from "push" & "pull_request"
-          github.event_name == 'create' &&
-          github.event.ref_type == 'tag'
+          github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-skipdist = true
+minversion = 3.18.0
+skipsdist = true
 ignore_path = tests
-envlist = py3{6,7,8,9}, lint, coverage
+envlist = py3{6,7,8,9}, lint, packaging, coverage
 
 [testenv]
 usedevelop = true
@@ -15,6 +16,8 @@ setenv =
     COVERAGE_FILE={env:COVERAGE_FILE:.coverage.{basepython}}
 commands =
     coverage run -m pytest . {posargs}
+allowlist_externals =
+    bash
 
 [testenv:coverage]
 parallel_show_output = true
@@ -30,6 +33,22 @@ deps =
     pre_commit
 commands =
     python -m pre_commit run {posargs:--all}
+
+[testenv:packaging]
+usedevelop = false
+skip_install = true
+deps =
+    collective.checkdocs >= 0.2
+    pep517 >= 0.5.0
+    twine >= 2.0.0
+commands =
+    bash -c "rm -rf {toxinidir}/dist/ {toxinidir}/build/ && mkdir -p {toxinidir}/dist/"
+    python -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}
+    twine check dist/*
 
 [flake8]
 exclude = .tox/,.venv/,dist/,build/,.eggs/


### PR DESCRIPTION
- adds packaging testing tox environment
- runs packaging as a github action
- fixes issue where release created on github did
  not trigger the release pipeline.