### PR TITLE
Add experimental support for ansible-test

### DIFF
--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -1,6 +1,9 @@
 import glob
 from os import path
 
+from tox_ansible._yaml import load_yaml
+
+from ..tox_ansible_test_case import ToxAnsibleTestCase
 from ..tox_lint_case import ToxLintCase
 from ..tox_molecule_case import ToxMoleculeCase
 from .scenario import Scenario
@@ -65,8 +68,46 @@ class Ansible(object):
         the structure of a test environment.
 
         :return: List of TestCase objects"""
+
+        # pylint: disable=fixme
+        # TODO(ssbarnea): Detect and enable only those tests that do exist
+        # to avoid confusing tox user.
+        ANSIBLE_TEST_COMMANDS = {
+            # "coverage",
+            "integration": {},
+            "network-integration": {},
+            "sanity": {"args": ["--requirements"]},
+            "shell": {},
+            # "units": {},
+            "windows-integration": {},
+        }
+
         tox_cases = []
         for scenario in self.scenarios:
             tox_cases.append(ToxMoleculeCase(scenario))
+
+        # if we are inside a collection, we also enable ansible-test support
+        galaxy_file = path.join(self.directory, "galaxy.yml")
+        if path.isfile(galaxy_file):
+            galaxy_config = load_yaml(galaxy_file)
+            for command in ANSIBLE_TEST_COMMANDS:
+                tox_cases.append(
+                    ToxAnsibleTestCase(
+                        "sanity",
+                        args=ANSIBLE_TEST_COMMANDS["sanity"]["args"],
+                        galaxy_config=galaxy_config,
+                    )
+                )
+            if path.isdir(path.join(self.directory, "tests", "unit")):
+                for command in ["units", "coverage"]:
+                    tox_cases.append(
+                        ToxAnsibleTestCase(command, galaxy_config=galaxy_config)
+                    )
+            if path.isdir(path.join(self.directory, "tests", "integration")):
+                for command in ["units", "coverage"]:
+                    tox_cases.append(
+                        ToxAnsibleTestCase(command, galaxy_config=galaxy_config)
+                    )
+
         tox_cases.append(ToxLintCase(tox_cases))
         return tox_cases

--- a/src/tox_ansible/tox_ansible_test_case.py
+++ b/src/tox_ansible/tox_ansible_test_case.py
@@ -1,0 +1,98 @@
+import os
+import sys
+
+from .tox_base_case import ToxBaseCase
+
+DEFAULT_DESCRIPTION = (
+    "Auto-generated environment to run: molecule test -s {scenario_name}"
+)
+
+
+# pylint: disable=too-many-instance-attributes
+class ToxAnsibleTestCase(ToxBaseCase):
+    def __init__(self, command, name_parts=None, args=None, galaxy_config=None):
+        """Create the base test case.
+
+        :param scenario: The scenario that this test case should run"""
+        _galaxy_fields = ("name", "namespace", "version")
+        self._cases = []
+        self.command = command
+        self.args = args or []
+        self.galaxy_config = galaxy_config or {}
+        if not galaxy_config or any(k not in galaxy_config for k in _galaxy_fields):
+            print(
+                "Invalid galaxy.yml content, missing one of "
+                "required keys %s but we got %s"
+                % (", ".join(_galaxy_fields), galaxy_config),
+                file=sys.stderr,
+            )
+            sys.exit(102)
+
+        self.namespace = galaxy_config["namespace"]
+        self.collection = galaxy_config["name"]
+        self.version = galaxy_config["version"]
+
+        if self.command == "coverage":
+            self.args = ["--venv", "--requirements"]
+
+        self._dependencies = [
+            # to build collections we want to be sure we use latest version
+            # of ansible-base, as older versions like 2.9 do not support
+            # ignore patterns. Install can be done with older versions.
+            "ansible-base>=2.10.3",
+            # ansible-test is missing to install them on py39:
+            "pylint",
+            "pytest",
+            "pytest-xdist",
+        ]
+        self._name_parts = name_parts or []
+        super().__init__()
+
+    def get_name(self):
+        return self.command
+
+    @property
+    def description(self):
+        return f"Auto-generated environment to run: ansible-test {self.command}"
+
+    def get_dependencies(self):
+        return self._dependencies
+
+    def get_working_dir(self):
+        """Get the directory where the test should be executed.
+
+        :return: Path where the test case should be executed from"""
+
+        return os.path.expanduser(
+            "~/.ansible/collections/ansible_collections/"
+            f"{self.namespace}/{self.collection}"
+        )
+
+    def get_commands(self, options):
+        if self.command != "coverage":
+            commands = [
+                ["ansible-test", self.command, *self.args],
+            ]
+        else:
+            commands = [
+                # avoid ansible-test failure to erase missing location...
+                ["mkdir", "-p", "tests/output/coverage"],
+                ["ansible-test", self.command, "erase", *self.args],
+                ["ansible-test", "units", "--coverage", *self.args],
+                ["ansible-test", "integration", "--coverage", *self.args],
+                ["ansible-test", self.command, "report", *self.args],
+            ]
+
+        return [
+            [
+                "bash",
+                "-c",
+                (
+                    f"cd {self._config.toxinidir} && "
+                    "ansible-galaxy collection build -v -f --output-path dist/ && "
+                    "ansible-galaxy collection install -f "
+                    f"dist/{self.namespace}-{self.collection}-{self.version}.tar.gz"
+                ),
+            ],
+            *commands,
+        ]

--- a/src/tox_ansible/tox_helper.py
+++ b/src/tox_ansible/tox_helper.py
@@ -109,9 +109,10 @@ class Tox(object):
         tox_case = config.tox_case
         if not config.description:
             config.description = tox_case.description
-        # Default commands to run molecule
-        if not config.commands:
-            config.commands = tox_case.get_commands(options)
+        # We do not want to use commands from existing default environment
+        # as these may likely be others tests. Generated environments will
+        # have their own internal commands.
+        config.commands = tox_case.get_commands(options)
         # Default deps to install molecule, etc
         if not config.deps:
             do = DepOption()

--- a/src/tox_ansible/tox_lint_case.py
+++ b/src/tox_ansible/tox_lint_case.py
@@ -16,7 +16,8 @@ class ToxLintCase(ToxBaseCase):
     def get_commands(self, options):
         cmds = []
         for case in self._cases:
-            if isinstance(case, ToxLintCase):
+            # Cases not supporting scenario are to be ignored
+            if not hasattr(case, "scenario"):
                 continue
             molecule_options = " ".join(options.get_global_opts())
             cmd = [

--- a/tests/fixtures/collection/galaxy.yml
+++ b/tests/fixtures/collection/galaxy.yml
@@ -1,0 +1,3 @@
+namespace: example
+name: foo
+version: 0.0.1

--- a/tests/fixtures/expand_collection/galaxy.yml
+++ b/tests/fixtures/expand_collection/galaxy.yml
@@ -1,0 +1,3 @@
+namespace: example
+name: foo
+version: 0.0.1

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -16,6 +16,7 @@ EXPECTED = {
             "roles-complex-name_mismatch",
             "roles-complex-openstack",
             "roles-simple-default",
+            "sanity",
             "two",
         ]
     ),
@@ -30,6 +31,7 @@ EXPECTED = {
             "py38-ansible28-roles-simple-default",
             "py38-ansible29-lint_all",
             "py38-ansible29-roles-simple-default",
+            "sanity",
         ]
     ),
     "tests/fixtures/not_collection": "\n".join(

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,9 +7,15 @@ from unittest import TestCase
 
 from tox_ansible.compat import TOX_PARALLEL_ENV
 
+GALAXY_SAMPLE = """
+namespace: example
+name: foo
+version: 0.0.1
+"""
 
-class ToxAnsibleTestCase(TestCase):
-    """A TestCAse for testing tox configs.
+
+class ToxAnsible_TestCase(TestCase):
+    """A TestCase for testing tox configs.
 
     This class creates a temporary directory, writing the provided contents to
     the tox config file and any scenario files.
@@ -35,7 +41,7 @@ class ToxAnsibleTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(ToxAnsibleTestCase, cls).setUpClass()
+        super().setUpClass()
 
         assert (
             cls.ini_contents is not None
@@ -53,7 +59,7 @@ class ToxAnsibleTestCase(TestCase):
 
         # Write the galaxy.yml file - blank for now
         with open(os.path.join(cls._temp_dir, "galaxy.yml"), "w") as galaxy_yml:
-            galaxy_yml.write("")
+            galaxy_yml.write(GALAXY_SAMPLE)
 
         # Create role and scenario dirs
         for role, scenarios in cls.roles:
@@ -72,7 +78,7 @@ class ToxAnsibleTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls._temp_dir)
-        super(ToxAnsibleTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     def _tox_call(self, arguments):
         # Remove TOX_PARALLEL_ENV from the subprocess environment variables


### PR DESCRIPTION
This change should enable tox-ansible to expose all ansible-test commands as generated tox cases, just like we expose molecule scenarios.

Please note that the support is only experimental and only `sanity` and `units` commands are implemented and that we may have to make breaking changes based on the feedback we receive from the first set of adopters.

Example output:
```bash
$ tox -va
using tox.ini: /Users/ssbarnea/c/a/tox-ansible/tox.ini (pid 83675)
using tox-3.20.1 from /Users/ssbarnea/.pyenv/versions/3.9.0/lib/python3.9/site-packages/tox/__init__.py (pid 83675)
default environments:
coverage                                              -> Auto-generated environment to run: ansible-test coverage
integration                                           -> Auto-generated environment to run: ansible-test integration
lint                                                  -> [no description]
lint_all                                              -> Auto-generated environment to run: molecule lint on all scenarios
network-integration                                   -> Auto-generated environment to run: ansible-test network-integration
packaging                                             -> [no description]
py36                                                  -> [no description]
py37                                                  -> [no description]
py38                                                  -> [no description]
py39                                                  -> [no description]
sanity                                                -> Auto-generated environment to run: ansible-test sanity
shell                                                 -> Auto-generated environment to run: ansible-test shell
tests-fixtures-collection-one                         -> Auto-generated environment to run: molecule test -s one
tests-fixtures-collection-roles-complex-default       -> Auto-generated environment to run: molecule test -s default
tests-fixtures-collection-roles-complex-name_mismatch -> Auto-generated environment to run: molecule test -s name_mismatch
tests-fixtures-collection-roles-complex-openstack     -> Auto-generated environment to run: molecule test -s openstack
tests-fixtures-collection-roles-simple-default        -> Auto-generated environment to run: molecule test -s default
tests-fixtures-collection-two                         -> Auto-generated environment to run: molecule test -s two
tests-fixtures-expand_collection-ignored-not_found    -> Auto-generated environment to run: molecule test -s not_found
tests-fixtures-expand_collection-roles-simple-default -> Auto-generated environment to run: molecule test -s default
tests-fixtures-not_collection-one                     -> Auto-generated environment to run: molecule test -s one
tests-fixtures-not_collection-two                     -> Auto-generated environment to run: molecule test -s two
units                                                 -> Auto-generated environment to run: ansible-test units
windows-integration                                   -> Auto-generated environment to run: ansible-test windows-integration
```

## Feedback needed
Please test it manually and post comments here so we do not make a 🍋.

Yes, I know that some tests are failing and that some ansible-test commands are not implemented. Please do focus on **sanity** and **units** or **integrations** if you happen to have any. If tox does not report any, you likely do not have them.