### PR TITLE
 Rename ToxTestCase to ToxMoleculeCase

### DIFF
--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -2,7 +2,7 @@ import glob
 from os import path
 
 from ..tox_lint_case import ToxLintCase
-from ..tox_test_case import ToxTestCase
+from ..tox_molecule_case import ToxMoleculeCase
 from .scenario import Scenario
 
 
@@ -64,6 +64,6 @@ class Ansible(object):
         :return: List of TestCase objects"""
         tox_cases = []
         for scenario in self.scenarios:
-            tox_cases.append(ToxTestCase(scenario))
+            tox_cases.append(ToxMoleculeCase(scenario))
         tox_cases.append(ToxLintCase(tox_cases))
         return tox_cases

--- a/src/tox_ansible/tox_lint_case.py
+++ b/src/tox_ansible/tox_lint_case.py
@@ -46,5 +46,5 @@ class ToxLintCase(ToxBaseCase):
 
     @property
     def description(self):
-        return "Auto-generated environment to run molecule lint on all "
+        return "Auto-generated environment to run: molecule lint on all scenarios"
         "scenarios"

--- a/src/tox_ansible/tox_molecule_case.py
+++ b/src/tox_ansible/tox_molecule_case.py
@@ -16,11 +16,11 @@ DRIVER_DEPENDENCIES = {
 
 
 DEFAULT_DESCRIPTION = (
-    "Auto-generated environment for Ansible role scenario {scenario_name}"
+    "Auto-generated environment to run: molecule test -s {scenario_name}"
 )
 
 
-class ToxTestCase(ToxBaseCase):
+class ToxMoleculeCase(ToxBaseCase):
     """Represents a generalized Test Case for an Ansible structure."""
 
     def __init__(self, scenario, name_parts=[]):
@@ -37,7 +37,7 @@ class ToxTestCase(ToxBaseCase):
             "testinfra",
         ]
         self._name_parts = name_parts
-        super(ToxTestCase, self).__init__()
+        super(ToxMoleculeCase, self).__init__()
 
     def get_commands(self, options):
         """Get the commands that this scenario should execute.

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from tox_ansible.matrix import Matrix, MatrixAxisBase
 from tox_ansible.matrix.axes import AnsibleAxis, PythonAxis
 from tox_ansible.tox_lint_case import ToxLintCase
-from tox_ansible.tox_test_case import ToxTestCase
+from tox_ansible.tox_molecule_case import ToxMoleculeCase
 
 try:
     from unittest import mock
@@ -14,7 +14,7 @@ except ImportError:
 
 class TestMatrix(TestCase):
     def test_empty_matrix(self):
-        cases = [ToxTestCase(mock.Mock()), ToxLintCase([])]
+        cases = [ToxMoleculeCase(mock.Mock()), ToxLintCase([])]
         original = copy(cases)
         matrix = Matrix()
         after_cases = matrix.expand(cases)

--- a/tests/test_tox_test_case.py
+++ b/tests/test_tox_test_case.py
@@ -8,7 +8,7 @@ except ImportError:
 from tox_ansible.ansible.scenario import Scenario
 from tox_ansible.options import Options
 from tox_ansible.tox_helper import Tox
-from tox_ansible.tox_test_case import ToxTestCase
+from tox_ansible.tox_molecule_case import ToxMoleculeCase
 
 DOCKER_DRIVER = {"driver": {"name": "docker"}}
 OPENSTACK_DRIVER = {"driver": {"name": "openstack"}}
@@ -16,11 +16,11 @@ BASE_DEPS = ["molecule", "ansible-lint", "yamllint", "flake8", "pytest", "testin
 
 
 @mock.patch.object(Scenario, "config", new_callable=mock.PropertyMock, return_value={})
-class TestToxTestCase(TestCase):
+class TestToxMoleculeCase(TestCase):
     @mock.patch.object(Options, "get_global_opts", return_value=[])
     @mock.patch.object(Tox, "posargs", new_callable=mock.PropertyMock, return_value=[])
     def test_case_is_simple(self, pos_mock, opts_mock, config_mock):
-        t = ToxTestCase(self.scenario)
+        t = ToxMoleculeCase(self.scenario)
         self.assertEqual(t.get_name(), "my_test")
         self.assertEqual(t.get_working_dir(), "")
         self.assertEqual(t.get_dependencies(), BASE_DEPS + ["ansible"])
@@ -31,12 +31,12 @@ class TestToxTestCase(TestCase):
     @mock.patch.object(Options, "get_global_opts", return_value=["-c", "derp"])
     @mock.patch.object(Tox, "posargs", new_callable=mock.PropertyMock, return_value=[])
     def test_case_has_global_opts(self, pos_mock, opts_mock, config_mock):
-        t = ToxTestCase(self.scenario)
+        t = ToxMoleculeCase(self.scenario)
         cmds = [["molecule", "-c", "derp", "test", "-s", self.scenario.name]]
         self.assertEqual(t.get_commands(self.opts), cmds)
 
     def test_case_expand_ansible(self, config_mock):
-        t = ToxTestCase(self.scenario)
+        t = ToxMoleculeCase(self.scenario)
         ts = t.expand_ansible("2.7")
         self.assertEqual(ts.ansible, "2.7")
         self.assertEqual(ts.get_name(), "ansible27-my_test")
@@ -44,14 +44,14 @@ class TestToxTestCase(TestCase):
         self.assertIsNone(ts.get_basepython())
 
     def test_case_expand_python(self, config_mock):
-        t = ToxTestCase(self.scenario)
+        t = ToxMoleculeCase(self.scenario)
         ts = t.expand_python("4.1")
         self.assertEqual(ts.python, "4.1")
         self.assertEqual(ts.get_name(), "py41-my_test")
         self.assertEqual(ts.get_basepython(), "python4.1")
 
     def test_case_expand_twice(self, config_mock):
-        t = ToxTestCase(self.scenario)
+        t = ToxMoleculeCase(self.scenario)
         t1 = t.expand_python("4.1")
         t2 = t1.expand_ansible("1.0")
         self.assertEqual(t2.get_name(), "ansible10-py41-my_test")
@@ -61,7 +61,7 @@ class TestToxTestCase(TestCase):
     )
     def test_case_includes_docker_deps(self, driver_mock, config_mock):
         s = Scenario("molecule/my_test")
-        t = ToxTestCase(s)
+        t = ToxMoleculeCase(s)
         self.assertIn("molecule-docker", t.get_dependencies())
 
     @mock.patch.object(
@@ -69,7 +69,7 @@ class TestToxTestCase(TestCase):
     )
     def test_case_includes_openstack_deps(self, driver_mock, config_mock):
         s = Scenario("molecule/osp_test")
-        t = ToxTestCase(s)
+        t = ToxMoleculeCase(s)
         self.assertIn("openstacksdk", t.get_dependencies())
 
     @classmethod


### PR DESCRIPTION
This refactoring addresses confusions regarding what this class does and makes it easier to makes it easier to add support for other testers, like ansible-test.