### PR TITLE
Allow execution from subfolders

### DIFF
--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -17,9 +17,12 @@ class Ansible(object):
         directory is an Ansible structure or not. Currently aware of a
         collection and a role.
 
-        :param base: Path to the folder. Defaluts to being relative to
+        :param base: Path to the folder. Defaults to being relative to
         os.path.curdir, but can be absolute"""
-        self.directory = path.abspath(path.join(path.curdir, base))
+        if path.isabs(base):
+            self.directory = base
+        else:
+            self.directory = path.abspath(path.join(path.curdir, base))
         self._scenarios = None
         self.options = options
 

--- a/src/tox_ansible/hooks.py
+++ b/src/tox_ansible/hooks.py
@@ -47,7 +47,7 @@ def tox_configure(config):
     combo that is discovered therein."""
     tox = tox_helper.Tox(config)
     options = Options(tox)
-    ansible = Ansible(options=options)
+    ansible = Ansible(options=options, base=tox.toxinidir)
 
     # Only execute inside of a collection, otherwise we have nothing to do
     if not ansible.is_ansible:


### PR DESCRIPTION
Fixes bug which prevented tox-ansible from finding scenarios when
tox was called from a subfolder.

Fixes: #43