### PR TITLE
Use specific github actios image

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@master
@@ -28,7 +28,7 @@ jobs:
           python -m pip install -U tox
           tox -e lint
   packaging:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@master
@@ -40,7 +40,7 @@ jobs:
           tox -e packaging
   test:
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +64,7 @@ jobs:
 
   coverage:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@master
@@ -84,7 +84,7 @@ jobs:
   publish:
     needs: coverage
     if: startsWith(github.ref, 'refs/tags/')  # Only release during tags
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       PY_COLORS: 1


### PR DESCRIPTION
Avoid warnings with github actions by using explicit version
of the image used for testing.