### PR TITLE
Add test for full run through

### DIFF
--- a/tests/fixtures/collection/roles/simple/molecule/default/converge.yml
+++ b/tests/fixtures/collection/roles/simple/molecule/default/converge.yml
@@ -1,0 +1,4 @@
+- name: test
+  hosts: all
+  roles:
+    - simple

--- a/tests/fixtures/collection/roles/simple/molecule/default/molecule.yml
+++ b/tests/fixtures/collection/roles/simple/molecule/default/molecule.yml
@@ -1,2 +1,5 @@
 driver:
-  name: docker
+  name: podman
+platforms:
+  - name: simple
+    image: fedora:latest

--- a/tests/fixtures/collection/roles/simple/tasks/main.yml
+++ b/tests/fixtures/collection/roles/simple/tasks/main.yml
@@ -1,2 +1,2 @@
 - name: say hello
-  debug: msg=hi
+  debug: msg='tox-ansible is the best'

--- a/tests/fixtures/collection/roles/simple/tasks/main.yml
+++ b/tests/fixtures/collection/roles/simple/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: say hello
+  debug: msg=hi

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import contextlib
 import os
+import shutil
 import subprocess
 from unittest.mock import patch
 
@@ -110,3 +111,10 @@ def test_run_tox_with_args(target, value, capfd):
             env = run_tox(["-l"], capfd)
     assert cli == EXPECTED_ARGS[value]
     assert env == EXPECTED_ARGS[value]
+
+
+def test_run_with_test_command(capfd):
+    with cd("tests/fixtures/collection"):
+        shutil.rmtree(".tox")
+        cli = run_tox(["-e", "roles-simple-default"], capfd)
+    assert cli != ""

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -117,4 +117,4 @@ def test_run_with_test_command(capfd):
     with cd("tests/fixtures/collection"):
         shutil.rmtree(".tox")
         cli = run_tox(["-e", "roles-simple-default"], capfd)
-    assert cli != ""
+    assert "tox-ansible is the best" in cli


### PR DESCRIPTION
Adds a test that executes a full run of tox + molecule (will require podman on testing device)
Uses that test to fix a bug in dependencies by restricting the version of rich that we can use

Fixes #54 