### PR TITLE
Use only current python for ansible-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,26 @@
 [![codecov](https://codecov.io/gh/ansible-community/tox-ansible/branch/master/graph/badge.svg)](https://codecov.io/gh/greg-hellings/tox-ansible)
 [![PyPI version](https://badge.fury.io/py/tox-ansible.svg)](https://badge.fury.io/py/tox-ansible)
 
-tox-ansible-collection
-======================
+tox-ansible
+===========
 
-This plugin for tox auto-generates tox environments for running Ansible
+This plugin for tox auto-generates tox environments for running
 quality assurance tools like ansible-test or molecule. Optionally, you can
-then elect to filter the environments down to only a subset of them.
+decide to filter the environments down to only a subset of them.
 The tool is rather tightly integrated for the official [Molecule](https://github.com/ansible/molecule)
 testing tool that integrates with [Ansible](https://github.com/ansible/ansible).
 
 ansible-test
 ------------
 
-As you probably already know, ansible-test cannot be just run on a cloned
-repository because it requires the current collection to be already installed
-and the current directory is already the installed location.
-
 This plugin saves you this trouble by allowing you the freedom to run
 these commands tranparently. For example you can run `tox -e sanity` which
 will install the collection, change current directory and execute
-`ansible-test sanity`. You can even add posargs that endup being passed to
-the executed command, like `tox -e sanity -- --help`.
+`ansible-test sanity --python X.Y`. You can even add posargs that endup being
+passed to the executed command, like `tox -e sanity -- --help`.
 
-To see all dynamically generated environments, just run `tox -va`, the
-description field will tell you what they do:
+By default tox-ansible will also limit execution of ansible-test to the
+current python version used by tox.
 
 ```shell
 $ tox -va

--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -1,4 +1,6 @@
+import copy
 import glob
+import sys
 from os import path
 from typing import Any, Dict
 
@@ -81,16 +83,20 @@ class Ansible(object):
             "network-integration": {},
             "sanity": {"args": ["--requirements"]},
             "shell": {},
-            # "units": {},
+            "units": {},
             "windows-integration": {},
         }
+
         # Append posargs if any to each command
-        if self.tox.posargs:
-            for value in ANSIBLE_TEST_COMMANDS.values():
-                if "args" not in value:
-                    value["args"] = self.tox.posargs
-                else:
-                    value["args"].extend(self.tox.posargs)
+        for value in ANSIBLE_TEST_COMMANDS.values():
+            if "args" not in value:
+                value["args"] = copy.deepcopy(self.tox.posargs)
+            else:
+                value["args"].extend(self.tox.posargs)
+            if "--python" not in self.tox.posargs:
+                value["args"].extend(
+                    ["--python", f"{sys.version_info[0]}.{sys.version_info[1]}"]
+                )
 
         tox_cases = []
         for scenario in self.scenarios:


### PR DESCRIPTION
Adds implicit option to only test current tox python interpreter
when running ansible-test and avoid almost guaranteed noise
from missing interpreters or ones that are not configured yet.