### PR TITLE
Fix ansible-test environment generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ current python version used by tox.
 ```shell
 $ tox -va
 default environments:
-sanity       -> Auto-generated environment to run: ansible-test sanity
+sanity       -> Auto-generated for: ansible-test sanity
 ```
 
 Only those enviroments that are detected will be listed. At least sanity will

--- a/src/tox_ansible/tox_ansible_test_case.py
+++ b/src/tox_ansible/tox_ansible_test_case.py
@@ -3,9 +3,7 @@ import sys
 
 from .tox_base_case import ToxBaseCase
 
-DEFAULT_DESCRIPTION = (
-    "Auto-generated environment to run: molecule test -s {scenario_name}"
-)
+DEFAULT_DESCRIPTION = "Auto-generated for: molecule test -s {scenario_name}"
 
 
 # pylint: disable=too-many-instance-attributes
@@ -53,7 +51,7 @@ class ToxAnsibleTestCase(ToxBaseCase):
 
     @property
     def description(self):
-        return f"Auto-generated environment to run: ansible-test {self.command}"
+        return f"Auto-generated for: ansible-test {self.command} {' '.join(self.args)}"
 
     def get_dependencies(self):
         return self._dependencies

--- a/src/tox_ansible/tox_lint_case.py
+++ b/src/tox_ansible/tox_lint_case.py
@@ -47,4 +47,4 @@ class ToxLintCase(ToxBaseCase):
 
     @property
     def description(self):
-        return "Auto-generated environment to run: molecule lint on all scenarios"
+        return "Auto-generated for: molecule lint on all scenarios"

--- a/src/tox_ansible/tox_molecule_case.py
+++ b/src/tox_ansible/tox_molecule_case.py
@@ -17,9 +17,7 @@ DRIVER_DEPENDENCIES = {
 }
 
 
-DEFAULT_DESCRIPTION = (
-    "Auto-generated environment to run: molecule test -s {scenario_name}"
-)
+DEFAULT_DESCRIPTION = "Auto-generated for: molecule test -s {scenario_name}"
 
 
 class ToxMoleculeCase(ToxBaseCase):

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -11,19 +11,21 @@ import pytest
 EXPECTED = {
     "tests/fixtures/collection": "\n".join(
         [
+            "env",
             "lint_all",
             "one",
             "roles-complex-default",
             "roles-complex-name_mismatch",
             "roles-complex-openstack",
             "roles-simple-default",
-            "sanity",
+            "shell",
             "two",
         ]
     ),
     "tests/fixtures/expand_collection": "\n".join(
         [
             "derp",
+            "env",
             "py27-ansible28-lint_all",
             "py27-ansible28-roles-simple-default",
             "py27-ansible29-lint_all",
@@ -32,7 +34,7 @@ EXPECTED = {
             "py38-ansible28-roles-simple-default",
             "py38-ansible29-lint_all",
             "py38-ansible29-roles-simple-default",
-            "sanity",
+            "shell",
         ]
     ),
     "tests/fixtures/not_collection": "\n".join(


### PR DESCRIPTION
- shortened description for generated envs
- included args for commands run by generated ens
- fixed conditions that prevented adding extra args to ansible-tests