### PR TITLE
Make lint_all highly opinionated

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ section key "molecule\_opts".
 To test with the latest versions of Ansible 2.7, 2.8, AND 2.9, add a comma-delimited list to the
 "[ansible]" section key "ansible".
 
+To pass a configuration file to "[ansible-lint](https://github.com/ansible-community/ansible-lint)",
+add the option "ansible\_lint\_config". Similarly to pass a config file option to
+"[yamllint](https://github.com/adrienverge/yamllint)", set the option "yamllint\_config" in
+the "[ansible]" section. Flake8 can be configured per its normal segment in your tox.ini file. All
+three of these commands are run as part of the "lint\_all" environment that this plugin creates.
+
 requirements.txt
 ----------------
 

--- a/src/tox_ansible/options.py
+++ b/src/tox_ansible/options.py
@@ -15,6 +15,8 @@ INI_PYTHON_VERSIONS = "python"
 INI_ANSIBLE_VERSIONS = "ansible"
 INI_MOLECULE_GLOBAL_OPTS = "molecule_opts"
 INI_IGNORE_PATHS = "ignore_path"
+INI_ANSIBLE_LINT_CONFIG = "ansible_lint_config"
+INI_YAMLLINT_CONFIG = "yamllint_config"
 
 
 class Options(object):
@@ -27,6 +29,8 @@ class Options(object):
         self.scenario = self._parse_opt(opts, SCENARIO_OPTION_NAME, SCENARIO_ENV_NAME)
         self.driver = self._parse_opt(opts, DRIVER_OPTION_NAME, DRIVER_ENV_NAME)
         self.matrix = Matrix()
+        self.ansible_lint = self.reader.getstring(INI_ANSIBLE_LINT_CONFIG)
+        self.yamllint = self.reader.getstring(INI_YAMLLINT_CONFIG)
 
         ansible = self.reader.getlist(INI_ANSIBLE_VERSIONS, sep=" ")
         if ansible:

--- a/tests/fixtures/expand_collection/tox.ini
+++ b/tests/fixtures/expand_collection/tox.ini
@@ -9,6 +9,8 @@ molecule_opts =
     --debug
 ignore_path =
     ignored
+ansible_lint_config = some/path.config
+yamllint = some/yamllint.config
 
 [testenv]
 usedevelop = false


### PR DESCRIPTION
Since molecule no longer includes a highly opinionated idea of linting
roles, and running "molecule lint" on all provided scenarios is highly
time consuming, we make the lint commands for tox-ansible highly
opinionated. We run ansible-lint, yamllint, and flake8 across the wohle
repository.

It is recommended that users configure these runs as appropriate to
their environment by doing things like ignoring the .tox, .cache, etc
directories