### PR TITLE
Avoid breaking tox with invalid galaxy.yml files

### DIFF
--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import logging
 import sys
 from os import path
 from typing import Any, Dict
@@ -139,13 +140,16 @@ class Ansible(object):
                     )
                 ):
                     continue
-                tox_cases.append(
-                    ToxAnsibleTestCase(
-                        command,
-                        args=ANSIBLE_TEST_COMMANDS[command]["args"],
-                        galaxy_config=galaxy_config,
+                try:
+                    tox_cases.append(
+                        ToxAnsibleTestCase(
+                            command,
+                            args=ANSIBLE_TEST_COMMANDS[command]["args"],
+                            galaxy_config=galaxy_config,
+                        )
                     )
-                )
+                except RuntimeError as exc:
+                    logging.warning(str(exc))
 
         tox_cases.append(ToxLintCase(tox_cases))
         return tox_cases

--- a/src/tox_ansible/tox_ansible_test_case.py
+++ b/src/tox_ansible/tox_ansible_test_case.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from .tox_base_case import ToxBaseCase
 
@@ -18,13 +17,11 @@ class ToxAnsibleTestCase(ToxBaseCase):
         self.args = args or []
         self.galaxy_config = galaxy_config or {}
         if not galaxy_config or any(k not in galaxy_config for k in _galaxy_fields):
-            print(
+            raise RuntimeError(
                 "Invalid galaxy.yml content, missing one of "
                 "required keys %s but we got %s"
-                % (", ".join(_galaxy_fields), galaxy_config),
-                file=sys.stderr,
+                % (", ".join(_galaxy_fields), galaxy_config)
             )
-            sys.exit(102)
 
         self.namespace = galaxy_config["namespace"]
         self.collection = galaxy_config["name"]


### PR DESCRIPTION
Instead of exiting when encountering an invalid galaxy.yml file, log
a warning message and continue.

This plugin should not break tox use even if configuration is
incorrect, graceful degradation being prefered.