### PR TITLE
Reduce maintennce burden for Molecule plugins

### DIFF
--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -125,8 +125,9 @@ class Ansible(object):
                 )
 
         tox_cases = []
+        drivers = {s.driver for s in self.scenarios}
         for scenario in self.scenarios:
-            tox_cases.append(ToxMoleculeCase(scenario))
+            tox_cases.append(ToxMoleculeCase(scenario, drivers=drivers))
 
         # if we are inside a collection, we also enable ansible-test support
         galaxy_file = path.join(self.directory, "galaxy.yml")

--- a/src/tox_ansible/tox_base_case.py
+++ b/src/tox_ansible/tox_base_case.py
@@ -63,7 +63,7 @@ class ToxBaseCase(object):
     def __copy__(self):
         obj = type(self).__new__(self.__class__)
         for k, v in self.__dict__.items():
-            if k in ("scenario", "_config"):
+            if k in ("scenario", "_config", "_drivers"):
                 obj.__dict__[k] = v
             else:
                 obj.__dict__[k] = copy.copy(v)

--- a/tests/fixtures/collection/molecule/one/molecule.yml
+++ b/tests/fixtures/collection/molecule/one/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/collection/molecule/two/molecule.yml
+++ b/tests/fixtures/collection/molecule/two/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/has_deps/molecule/one/molecule.yml
+++ b/tests/fixtures/has_deps/molecule/one/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/has_deps/molecule/two/molecule.yml
+++ b/tests/fixtures/has_deps/molecule/two/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/not_collection/molecule/one/molecule.yml
+++ b/tests/fixtures/not_collection/molecule/one/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/not_collection/molecule/two/molecule.yml
+++ b/tests/fixtures/not_collection/molecule/two/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/simplified/molecule/default/molecule.yml
+++ b/tests/fixtures/simplified/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated

--- a/tests/fixtures/simplified/molecule/two/molecule.yml
+++ b/tests/fixtures/simplified/molecule/two/molecule.yml
@@ -1,0 +1,2 @@
+driver:
+  name: delegated


### PR DESCRIPTION
When a driver is detected, default to installing "molecule-{driver}" for
cases where we don't know any extra deps. Also, only install deps for
drivers detected in the current repository

Addresses #85