### PR TITLE
Make driver parsing more resilient

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.9.1
     hooks:
       - id: isort
   - repo: https://github.com/python/black.git
-    rev: 20.8b1
+    rev: 21.6b0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -19,18 +19,18 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
+    rev: v1.26.1
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.910
     hooks:
       - id: mypy
         # empty args needed in order to match mypy cli behavior
@@ -39,8 +39,9 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - py>=1.9.0
+          - types-PyYAML
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.6.0
+    rev: v3.0.0a3
     hooks:
       - id: pylint
         additional_dependencies:

--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -166,7 +166,7 @@ class Ansible(object):
                 )
 
         tox_cases = []
-        drivers = {s.driver for s in self.scenarios}
+        drivers = {s.driver for s in self.scenarios if s.driver}
         for scenario in self.scenarios:
             tox_cases.append(ToxMoleculeCase(scenario, drivers=drivers))
 

--- a/src/tox_ansible/tox_molecule_case.py
+++ b/src/tox_ansible/tox_molecule_case.py
@@ -1,7 +1,7 @@
 import os
 from functools import lru_cache
 from string import Template
-from typing import Iterable
+from typing import Iterable, List, Optional
 
 from .options import INI_SCENARIO_FORMAT_DEFAULT
 from .tox_base_case import ToxBaseCase
@@ -26,7 +26,7 @@ DEFAULT_DESCRIPTION = "Auto-generated for: {cwd_cmd}molecule test -s {scenario_n
 class ToxMoleculeCase(ToxBaseCase):
     """Represents a generalized Test Case for an Ansible structure."""
 
-    def __init__(self, scenario, name_parts=None, drivers=None):
+    def __init__(self, scenario, name_parts=None, drivers: Optional[List[str]] = None):
         """Create the base test case.
 
         :param scenario: The scenario that this test case should run"""
@@ -44,7 +44,7 @@ class ToxMoleculeCase(ToxBaseCase):
             self._drivers = drivers
         else:
             self._drivers = []
-        super().__init__()
+        super().__init__()  # type: ignore
 
     def get_commands(self, options):
         """Get the commands that this scenario should execute.

--- a/tests/util.py
+++ b/tests/util.py
@@ -86,6 +86,7 @@ class ToxAnsible_TestCase(TestCase):
         env = os.environ.copy()
         env.pop(TOX_PARALLEL_ENV, None)
 
+        # pylint: disable=consider-using-with
         proc = subprocess.Popen(
             arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
         )


### PR DESCRIPTION
Avoids an exception like below when running `tox -va`:

  File "/Users/ssbarnea/.pyenv/versions/3.9.5/lib/python3.9/site-packages/tox_ansible/tox_molecule_case.py", line 86, in get_dependencies
    dependencies.append("molecule-" + driver)
TypeError: can only concatenate str (not "NoneType") to str